### PR TITLE
Support Composerkit folder structure in SQLite path detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ The plugin provides an endpoint `/kirby-stats/hit` which gets called from a litt
     // Allowed values: 'hour', 'day', 'week', 'month', 'year'.
     'interval' => 'hour',
 
-    // Where to (automatically) create the database. Default is
-    // '/storage/stats.sqlite' for public folder setups or
-    // '/site/storage/stats.sqlite' for normal setups.
+    // Where to (automatically) create the database. Default is:
+    // - '/storage/stats.sqlite' if 'storage' root is defined (e.g. in public folder setups)
+    // - '/data/storage/stats.sqlite' if 'data' root is defined (e.g. in composerkit)
+    // - '/site/storage/stats.sqlite' as fallback for default Kirby setups
     'sqlite' => dirname(__DIR__) . '/some-file-path.sqlite',
   ],
 ];

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "arnoson/kirby-stats",
   "description": "Simple and privacy friendly web statistics for Kirby CMS.",
   "type": "kirby-plugin",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "autoload": {
     "psr-4": {
       "arnoson\\KirbyStats\\": "lib"

--- a/index.php
+++ b/index.php
@@ -13,9 +13,17 @@ load([
 App::plugin('arnoson/kirby-stats', [
   'options' => [
     'enabled' => true,
-    'sqlite' => kirby()->root('storage')
-      ? kirby()->root('storage') . '/stats.sqlite'
-      : kirby()->root('site') . '/storage/stats.sqlite',
+    'sqlite' => (function () {
+      if ($storage = kirby()->root('storage')) {
+        return $storage . '/stats.sqlite';
+      }
+
+      if ($data = kirby()->root('data')) {
+        return $data . '/storage/stats.sqlite';
+      }
+
+      return kirby()->root('site') . '/storage/stats.sqlite';
+    })(),
     'ignoreDirs' => ['panel', 'api', 'assets', 'media'],
   ],
   'routes' => include __DIR__ . '/routes/routes.php',


### PR DESCRIPTION
This enhances the default configuration to support the [Kirby ComposerKit setup](https://github.com/getkirby/composerkit), which separates data and public folders.

Previously, users needed to manually set the `sqlite` option or extend their `index.php` to define a `storage` root. With this update, the plugin will automatically detect and support the following setups:

- **Standard Kirby** (`site/storage/stats.sqlite`)
- **Public folder setups** (`storage/stats.sqlite`)
- **ComposerKit setups** (`data/storage/stats.sqlite`)

The `sqlite` option is now determined by an immediately invoked function that:

1. Checks if `kirby()->root('storage')` exists → uses `storage/stats.sqlite`
2. Falls back to `kirby()->root('data') . '/storage/stats.sqlite'` (Composerkit)
3. Defaults to `kirby()->root('site') . '/storage/stats.sqlite'`

No breaking changes — this is a backward-compatible enhancement.