### PR TITLE
fix: localize count column label in pages-section

### DIFF
--- a/src/components/pages-section.vue
+++ b/src/components/pages-section.vue
@@ -97,7 +97,11 @@ watch(filteredRows, () => paginate({ page: 1 }))
       :index="false"
       :columns="{
         name: { label: t('page'), type: 'kirby-stats-percent', mobile: true },
-        count: { label: capitalize(type), width: '8em', mobile: true },
+        count: {
+          label: t('arnoson.kirby-stats.' + type) || capitalize(type),
+          width: '8em',
+          mobile: true,
+        },
       }"
       :rows="paginatedRows"
       :pagination="{ ...pagination, details: true, total: filteredRows.length }"


### PR DESCRIPTION
Updated the count column label to use a localized string from the translation key 'arnoson.kirby-stats.{type}', falling back to capitalized type if translation is unavailable.